### PR TITLE
bugfix: add missing ReturnTypeWillChange attributes

### DIFF
--- a/src/DotArray.php
+++ b/src/DotArray.php
@@ -289,6 +289,7 @@ class DotArray implements ArrayAccess, Countable, IteratorAggregate, JsonSeriali
      * @param  int|string $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -356,6 +357,7 @@ class DotArray implements ArrayAccess, Countable, IteratorAggregate, JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->_ITEMS;


### PR DESCRIPTION
Some methods need ReturnTypeWillChange attributes

Result of `php vendor/bin/phpunit` without changes
```
PHP Deprecated:  Return type of Pharaonic\DotArray\DotArray::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...
PHP Deprecated:  Return type of Pharaonic\DotArray\DotArray::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...
```